### PR TITLE
Upgrade cssselect

### DIFF
--- a/dryscrape/mixins.py
+++ b/dryscrape/mixins.py
@@ -3,7 +3,7 @@ Mixins for use in dryscrape drivers.
 """
 
 import time
-from lxml.cssselect import css_to_xpath
+from cssselect import GenericTranslator
 import lxml.html
 
 class SelectionMixin(object):
@@ -12,7 +12,7 @@ class SelectionMixin(object):
 
   def css(self, css):
     """ Returns all nodes matching the given CSSv3 expression. """
-    return self.xpath(css_to_xpath(css))
+    return self.xpath(GenericTranslator().css_to_xpath(css))
 
   def at_css(self, css):
     """ Returns the first node matching the given CSSv3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml
 git+git://github.com/niklasb/webkit-server.git
+cssselect


### PR DESCRIPTION
lxml now depends on cssselect. The css_to_xpath() function no longer exists.
