### PR TITLE
Allow for autocompletion to detect Sesson driver proxy methods

### DIFF
--- a/dryscrape/session.py
+++ b/dryscrape/session.py
@@ -1,4 +1,6 @@
 from dryscrape.driver.webkit import Driver as DefaultDriver
+
+from itertools import chain
 try:
   import urlparse
 except ImportError:
@@ -26,6 +28,11 @@ class Session(object):
   def __getattr__(self, attr):
     """ Pass unresolved method calls to underlying driver. """
     return getattr(self.driver, attr)
+
+  def __dir__(self):
+    """Allow for `dir` to detect proxied methods from `Driver`."""
+    dir_chain = chain(dir(type(self)), dir(self.driver))
+    return list(set(dir_chain))
 
   def visit(self, url):
     """ Passes through the URL to the driver after completing it using the


### PR DESCRIPTION
Hi, I've added a method to the `Session` class to allow for the `dir` builtin and ipython to detect the methods that `Session` proxies from `Driver`. This allows easier exploration of the module for newbies without needing to consult the documentation and makes what methods `Session` is supposed to have clearer.