### PR TITLE
Remove removal of DISPLAY environment variable

### DIFF
--- a/dryscrape/xvfb.py
+++ b/dryscrape/xvfb.py
@@ -5,13 +5,13 @@ _xvfb = None
 
 
 def start_xvfb():
-    from xvfbwrapper import Xvfb
-    global _xvfb
-    _xvfb = Xvfb()
-    _xvfb.start()
-    atexit.register(_xvfb.stop)
+  from xvfbwrapper import Xvfb
+  global _xvfb
+  _xvfb = Xvfb()
+  _xvfb.start()
+  atexit.register(_xvfb.stop)
 
 
 def stop_xvfb():
-    global _xvfb
-    _xvfb.stop()
+  global _xvfb
+  _xvfb.stop()

--- a/dryscrape/xvfb.py
+++ b/dryscrape/xvfb.py
@@ -3,15 +3,15 @@ import os
 
 _xvfb = None
 
+
 def start_xvfb():
-  from xvfbwrapper import Xvfb
-  global _xvfb
-  if "DISPLAY" in os.environ:
-    del os.environ["DISPLAY"]
-  _xvfb = Xvfb()
-  _xvfb.start()
-  atexit.register(_xvfb.stop)
+    from xvfbwrapper import Xvfb
+    global _xvfb
+    _xvfb = Xvfb()
+    _xvfb.start()
+    atexit.register(_xvfb.stop)
+
 
 def stop_xvfb():
-  global _xvfb
-  _xvfb.stop()
+    global _xvfb
+    _xvfb.stop()


### PR DESCRIPTION
The issue has to do with the lines 9-10:

```python
if "DISPLAY" in os.environ:
    del os.environ["DISPLAY"]
```

This seems to remove the DISPLAY environment variable unnecessarily, as on line 50 of [xvfbwrapper.py](https://github.com/cgoldberg/xvfbwrapper/blob/master/xvfbwrapper.py), self.orig_display is set to the value of DISPLAY.

```python
if 'DISPLAY' in os.environ:
    self.orig_display = os.environ['DISPLAY'].split(':')[1]
```

self.orig_display is checked on line 83, which is where the error occurs. Because of xvfb.py removing the environment variable and self.orig_display being set to the original value, on line 84 when it tries to remove DISPLAY, it has already been removed by xvfb.py, so it throws a KeyError.

```python
if self.orig_display is None:
    del os.environ['DISPLAY']
```



The solution is simply to remove the removal of the DISPLAY environment variable in xvfb.py, as it is already handled by xvfbwrapper.py